### PR TITLE
Cleanup and comments + fix C external variables.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.o
 os-image
 bochs_w_sti.txt
+bochs/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ os-image
 bochs_w_sti.txt
 bochs/
 ld_help.txt
+gcc_man.txt

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bochs/
 ld_help.txt
 gcc_man.txt
 nasm_man.txt
+objdump_help.txt

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bochs_w_sti.txt
 bochs/
 ld_help.txt
 gcc_man.txt
+nasm_man.txt

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 os-image
 bochs_w_sti.txt
 bochs/
+ld_help.txt

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ boot_sect.bin: boot/boot_sect.asm
 	nasm -O0 $< -I 'boot/' -f bin -o $@
 
 kernel.bin: kernel_entry.o kernel.o screen.o low_level.o keyboard.o ps_2_ctlr.o idt_v_print.o
-	i386-elf-ld -Og -o $@ -Ttext 0x1000 $^ --oformat binary
+	i386-elf-ld -O0 -o $@ -Ttext 0x1000 $^ --oformat binary
 
 #    Build the kernel object file.
 #    kernel.o: kernel/kernel.c
@@ -45,23 +45,23 @@ kernel.bin: kernel_entry.o kernel.o screen.o low_level.o keyboard.o ps_2_ctlr.o 
 # IMPORTANT: The % operator does not match sub-directories, hence `kernel/%.c`.
 # kernel/%.c
 kernel.o: kernel/kernel.c kernel/kernel.h
-	i386-elf-gcc -Wall -Wextra -Werror -Og -ffreestanding -c $< -o $@
+	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
 
 idt_v_print.o: kernel/idt_v_print.c kernel/idt_v_print.h
-	i386-elf-gcc -Wall -Wextra -Werror -Og -ffreestanding -c $< -o $@
+	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
 
 screen.o: drivers/screen.c drivers/screen.h
-	i386-elf-gcc -Wall -Wextra -Werror -Og -ffreestanding -c $< -o $@
+	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
 
 keyboard.o: drivers/keyboard.c drivers/keyboard.h
-	i386-elf-gcc -Wall -Wextra -Werror -Og -ffreestanding -c $< -o $@
+	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
 
 ps_2_ctlr.o: drivers/ps_2_ctlr.c drivers/ps_2_ctlr.h
-	i386-elf-gcc -Wall -Wextra -Werror -Og -ffreestanding -c $< -o $@
+	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
 
 # The use of -masm=intel below changes the syntax for the inline assembly from GAS to NASM.
 low_level.o: kernel/low_level.c kernel/low_level.h
-	i386-elf-gcc -Wall -Wextra -Werror -Og -ffreestanding -c $< -o $@
+	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
 
 # Build the kernel entry object file.
 # [] Add .asm files as dep. and test make reports changes.

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ OBJ = ${C_SOURCES:.c=.o}
 all: os-image
 
 run: all
-	bochs -q
+	./bochs/bochs -q -f bochsrc.txt
 
 runq: all
 	qemu-system-i386 -drive file=os-image,if=floppy,format=raw

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ os-image: boot_sect.bin kernel.bin
 boot_sect.bin: boot/boot_sect.asm
 	nasm -O0 $< -I 'boot/' -f bin -o $@
 
-kernel.bin: kernel_entry.o kernel.o screen.o low_level.o keyboard.o ps_2_ctlr.o idt_v_print.o
+kernel.bin: kernel_entry.o kernel.o screen.o low_level.o keyboard.o ps_2_ctlr.o idt_v_print.o idt.o
 	i386-elf-ld -O0 -o $@ -Ttext 0x1000 $^ --oformat binary
 
 #    Build the kernel object file.
@@ -44,21 +44,27 @@ kernel.bin: kernel_entry.o kernel.o screen.o low_level.o keyboard.o ps_2_ctlr.o 
 # Generic rule for building 'somefile.o' from 'somefile.c'.
 # IMPORTANT: The % operator does not match sub-directories, hence `kernel/%.c`.
 # kernel/%.c
-%.o: kernel/%.c
-	i386-elf-gcc -Wall -O0 -ffreestanding -c $< -o $@
+kernel.o: kernel/kernel.c kernel/kernel.h
+	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
+
+idt.o: kernel/idt.c kernel/idt.h
+	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
+
+idt_v_print.o: kernel/idt_v_print.c kernel/idt_v_print.h
+	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
 
 screen.o: drivers/screen.c drivers/screen.h
-	i386-elf-gcc -Wall -O0 -ffreestanding -c $< -o $@
+	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
 
 keyboard.o: drivers/keyboard.c drivers/keyboard.h
-	i386-elf-gcc -Wall -O0 -ffreestanding -c $< -o $@
+	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
 
 ps_2_ctlr.o: drivers/ps_2_ctlr.c drivers/ps_2_ctlr.h
-	i386-elf-gcc -Wall -O0 -ffreestanding -c $< -o $@
+	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
 
 # The use of -masm=intel below changes the syntax for the inline assembly from GAS to NASM.
 low_level.o: kernel/low_level.c kernel/low_level.h
-	i386-elf-gcc -Wall -masm=intel -O0 -ffreestanding -c $< -o $@
+	i386-elf-gcc -Wall -Wextra -Werror -masm=intel -O0 -ffreestanding -c $< -o $@
 
 # Build the kernel entry object file.
 # [] Add .asm files as dep. and test make reports changes.

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ boot_sect.bin: boot/boot_sect.asm
 	nasm -O0 $< -I 'boot/' -f bin -o $@
 
 kernel.bin: kernel_entry.o kernel.o screen.o low_level.o keyboard.o ps_2_ctlr.o idt_v_print.o
-	i386-elf-ld -O0 -o $@ -Ttext 0x1000 $^ --oformat binary
+	i386-elf-ld -Og -o $@ -Ttext 0x1000 $^ --oformat binary
 
 #    Build the kernel object file.
 #    kernel.o: kernel/kernel.c
@@ -45,23 +45,23 @@ kernel.bin: kernel_entry.o kernel.o screen.o low_level.o keyboard.o ps_2_ctlr.o 
 # IMPORTANT: The % operator does not match sub-directories, hence `kernel/%.c`.
 # kernel/%.c
 kernel.o: kernel/kernel.c kernel/kernel.h
-	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
+	i386-elf-gcc -Wall -Wextra -Werror -Og -ffreestanding -c $< -o $@
 
 idt_v_print.o: kernel/idt_v_print.c kernel/idt_v_print.h
-	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
+	i386-elf-gcc -Wall -Wextra -Werror -Og -ffreestanding -c $< -o $@
 
 screen.o: drivers/screen.c drivers/screen.h
-	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
+	i386-elf-gcc -Wall -Wextra -Werror -Og -ffreestanding -c $< -o $@
 
 keyboard.o: drivers/keyboard.c drivers/keyboard.h
-	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
+	i386-elf-gcc -Wall -Wextra -Werror -Og -ffreestanding -c $< -o $@
 
 ps_2_ctlr.o: drivers/ps_2_ctlr.c drivers/ps_2_ctlr.h
-	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
+	i386-elf-gcc -Wall -Wextra -Werror -Og -ffreestanding -c $< -o $@
 
 # The use of -masm=intel below changes the syntax for the inline assembly from GAS to NASM.
 low_level.o: kernel/low_level.c kernel/low_level.h
-	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
+	i386-elf-gcc -Wall -Wextra -Werror -Og -ffreestanding -c $< -o $@
 
 # Build the kernel entry object file.
 # [] Add .asm files as dep. and test make reports changes.

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,10 @@ OBJ = ${C_SOURCES:.c=.o}
 all: os-image
 
 run: all
-	./bochs/bochs -q -f bochsrc.txt
+	bochs -q -f bochsrc.txt # run bochs installed by mac ports.
+
+rundbg: all
+	./bochs/bochs -q -f bochsrc.txt # run bochs compiled from source. Required to use bochs' debugging features.
 
 runq: all
 	qemu-system-i386 -drive file=os-image,if=floppy,format=raw

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ ps_2_ctlr.o: drivers/ps_2_ctlr.c drivers/ps_2_ctlr.h
 
 # The use of -masm=intel below changes the syntax for the inline assembly from GAS to NASM.
 low_level.o: kernel/low_level.c kernel/low_level.h
-	i386-elf-gcc -Wall -Wextra -Werror -masm=intel -O0 -ffreestanding -c $< -o $@
+	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
 
 # Build the kernel entry object file.
 # [] Add .asm files as dep. and test make reports changes.

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ os-image: boot_sect.bin kernel.bin
 boot_sect.bin: boot/boot_sect.asm
 	nasm -O0 $< -I 'boot/' -f bin -o $@
 
-kernel.bin: kernel_entry.o kernel.o screen.o low_level.o keyboard.o ps_2_ctlr.o idt_v_print.o idt.o
+kernel.bin: kernel_entry.o kernel.o screen.o low_level.o keyboard.o ps_2_ctlr.o idt_v_print.o
 	i386-elf-ld -O0 -o $@ -Ttext 0x1000 $^ --oformat binary
 
 #    Build the kernel object file.
@@ -45,9 +45,6 @@ kernel.bin: kernel_entry.o kernel.o screen.o low_level.o keyboard.o ps_2_ctlr.o 
 # IMPORTANT: The % operator does not match sub-directories, hence `kernel/%.c`.
 # kernel/%.c
 kernel.o: kernel/kernel.c kernel/kernel.h
-	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
-
-idt.o: kernel/idt.c kernel/idt.h
 	i386-elf-gcc -Wall -Wextra -Werror -O0 -ffreestanding -c $< -o $@
 
 idt_v_print.o: kernel/idt_v_print.c kernel/idt_v_print.h

--- a/bochsrc.txt
+++ b/bochsrc.txt
@@ -1,20 +1,21 @@
-# FYI: 1.9.2. How do you pronounce "Bochs"?
-# Phonetically the same as the English word "box". It's just a play on the word
-# "box", since techies like to call their machines a "Linux box", "Windows box",
-# ... Bochs emulates a box inside a box.
+# Bochs is a program that simulates a complete Intel x86 computer.
+# ===
+# * This is the bochs configuration file.
+# * [Bochs User Manual](http://bochs.sourceforge.net/doc/docbook/user/index.html).
+# * FYI:
+#   * How do you pronounce "Bochs"? Phonetically the same as the English word "box".
+#   * To quit bochs with keyboard -> CMD+CRTL, then press SPACE.
+#   * for bochs installed with macports, ROM images are located at `/opt/local/share/bochs/`.
+#   * for bochs built from source, `./bochs/bios/`.
+# ##############################################################################
 
-# RTFM: http://bochs.sourceforge.net/doc/docbook/user/index.html
-#       http://bochs.sourceforge.net/doc/docbook/user/using-bochs.html#COMMANDLINE
 
-# FYI: To quit bochs with keyboard -> CMD+CRTL, then press SPACE.
-
-# Tell bochs to use our boot sector code as though it were a floppy disk
-# inserted into a computer at boot time.
-floppya: 1_44=os-image, status=inserted
-boot: a
-
-# FYI: ROM Images are located at `/opt/local/share/bochs/` , bios.bin-1.13.0 , BIOS-bochs-legacy, BIOS-bochs-latest
-
-romimage: file=/opt/local/share/bochs/BIOS-bochs-legacy
-
+romimage: file=./bochs/bios/BIOS-bochs-latest
+vgaromimage: file=./bochs/bios/VGABIOS-lgpl-latest
 keyboard: type=mf
+
+# * Tell bochs to use our boot sector code as though it were a floppy disk inserted into a computer at boot time.
+
+floppya: 1_44=os-image, status=inserted    # media_type=image_file. [floppya/floppyb](http://bochs.sourceforge.net/doc/docbook/user/bochsrc.html#BOCHSOPT-FLOPPYAB).
+boot: a                                    # This defines the boot sequence. Legacy 'a'.
+

--- a/bochsrc.txt
+++ b/bochsrc.txt
@@ -19,3 +19,4 @@ keyboard: type=mf
 floppya: 1_44=os-image, status=inserted    # media_type=image_file. [floppya/floppyb](http://bochs.sourceforge.net/doc/docbook/user/bochsrc.html#BOCHSOPT-FLOPPYAB).
 boot: a                                    # This defines the boot sequence. Legacy 'a'.
 
+# gdbstub: enabled=0, port=1234, text_base=0x1000    # Enable gdb debugging.

--- a/boot/boot_sect.asm
+++ b/boot/boot_sect.asm
@@ -37,7 +37,7 @@ mov bx, MSG_LOAD_KERNEL ; Print.
 call print_string
 
 mov bx, KERNEL_OFFSET ; disk_load function, argument for destination address is passed in ES:BX, this assumes ES == 0.
-mov dh, 15 ; disk_load function, argument for the number of sectors to read from the drive is passed in DH. 15 is an arbitrary large number given by the author. So we don't need to adjust this frequently as our kernel code grows.
+mov dh, 20 ; disk_load function, argument for the number of sectors to read from the drive is passed in DH. 15 is an arbitrary large number given by the author. So we don't need to adjust this frequently as our kernel code grows.
 mov dl, [BOOT_DRIVE] ; disk_load function, argument indicating which drive to read from is passed in DL.
 
 call disk_load ; Note, this function skips the reading first sector, which should be our boot sector.

--- a/boot/idt.asm
+++ b/boot/idt.asm
@@ -88,6 +88,8 @@
 ;db 00001110b       ; P (15)  DPL (14<-13) constant (12)  D (11) constant (10<-8)
 ;dw 0x0000          ; Offset high (31<-16)
 
+
+; [ ] .align 8? iSDM.Vol.3.Ch.6.11.
 idt_start:
 ;- - - - - - - vector 0 - - - - - - -;
 dw v_0_handler_procedure

--- a/boot/switch_to_pm.asm
+++ b/boot/switch_to_pm.asm
@@ -27,7 +27,7 @@ init_pm:
 mov ax, DATA_SEG; Now in PM, our old segments are meaningless, so we point our segment
 ; registers to the data segment descriptor in our GDT.
 ; Note the use of the 16 bit AX register here.
-mov ds, ax
+mov ds, ax ; NOTE that the CS code segment register does not appear here. [x] Confirm that the `jmp CODE_SEG:init_pm` instruction above loads the CS register. Confirmed. "Important: The way a far jump works in x86 means that the CPU will automatically update our cs register to the target segment used in the far jump instruction."
 mov ss, ax
 mov es, ax
 mov fs, ax

--- a/c_to_asm/Makefile
+++ b/c_to_asm/Makefile
@@ -2,8 +2,11 @@ MAINFILE := c0
 
 all: $(MAINFILE).bin
 
+#%.bin: %.o
+#	i386-elf-ld -O0 -o $@ -Ttext 0x0 --oformat binary $^
+
 %.bin: %.o
-	i386-elf-ld -O0 -o $@ -Ttext 0x0 --oformat binary $^
+	i386-elf-ld -O0 -o $@ -Ttext 0x0 --oformat elf32-i386 $^
 
 $(MAINFILE).o: $(MAINFILE).c
 	i386-elf-gcc -O0 -Wall -Wextra -ffreestanding -c $< -o $@

--- a/c_to_asm/Makefile
+++ b/c_to_asm/Makefile
@@ -1,0 +1,18 @@
+MAINFILE := c0
+
+all: $(MAINFILE).bin
+
+%.bin: %.o
+	i386-elf-ld -O0 -o $@ -Ttext 0x0 --oformat binary $^
+
+$(MAINFILE).o: $(MAINFILE).c
+	i386-elf-gcc -O0 -Wall -Wextra -ffreestanding -c $< -o $@
+
+ndis: $(MAINFILE).bin
+	ndisasm -b 32 $<
+
+objd: $(MAINFILE).o
+	i386-elf-objdump -d $< -M intel
+
+clean:
+	rm -Rf *.bin *.o

--- a/c_to_asm/c0.c
+++ b/c_to_asm/c0.c
@@ -1,0 +1,49 @@
+/*
+int my_function(void) {
+    return 0xbaba;
+}
+*/
+
+/*
+int my_function(void) {
+    int my_var = 0xbaba;
+    return my_var;
+}
+*/
+
+/*
+int callee_function(int my_arg);
+
+void caller_function(void) {
+    callee_function(0xdede);
+}
+
+int callee_function(int my_arg) {
+    return my_arg;
+}
+*/
+
+
+/*
+
+The disassembly of the following function does not match Nick Blundell's text.
+Why?
+
+* Nick Blundell may have made a typo in the commands he specifies for disassembling. He is also working on a Linux system with Linux build tools. Differences are to be expected.
+
+* If you disassemble the object file with `i386-elf-objdump`, linking hasn't happened yet, so addresses will not appear as they would in the final executable.
+
+* The use of `ld --oformat binary` seems to throw off the disassembly. `ld --oformat elf32-i386` seems to produce more reasonable results when the disassembly looks strange.
+
+* The safest option seems to be to use `ndisasm -b 32`. The extra instructions at the end can be ignored because:
+"The only problem with disassembling machine code is that some of those bytes
+may have been reserved as data but will show up as assembly instructions,
+though in our simple C program we didn’t declare any data."
+
+*/
+
+void my_function(void) {
+    char *my_string = "Hello"; // Nick Blundell wrote this `char *my_string = "Hello";` but he meant `char my_string[] = "Hello";`
+}
+
+

--- a/c_to_asm/c0.c
+++ b/c_to_asm/c0.c
@@ -1,17 +1,17 @@
-/*
+#if 0
 int my_function(void) {
     return 0xbaba;
 }
-*/
+#endif
 
-/*
+#if 1
 int my_function(void) {
     int my_var = 0xbaba;
     return my_var;
 }
-*/
+#endif
 
-/*
+#if 0
 int callee_function(int my_arg);
 
 void caller_function(void) {
@@ -21,7 +21,7 @@ void caller_function(void) {
 int callee_function(int my_arg) {
     return my_arg;
 }
-*/
+#endif
 
 
 /*
@@ -42,8 +42,10 @@ though in our simple C program we didn’t declare any data."
 
 */
 
+#if 0
 void my_function(void) {
     char *my_string = "Hello"; // Nick Blundell wrote this `char *my_string = "Hello";` but he meant `char my_string[] = "Hello";`
 }
+#endif
 
 

--- a/drivers/screen.c
+++ b/drivers/screen.c
@@ -335,17 +335,18 @@ void print_byteb (unsigned char b) {
 char nibtoa (unsigned char b) {
     b = 0x0F & b; // lower nibble.
 
-    if (b >= 0 && b <= 9)
+    if (b <= 9)
         b += '0';
     else if (b > 9)
         b = b - 10 + 'A';
     return b;
 }
 
-void print_byteh (unsigned char b) {
+void print_byteh (unsigned char b, int pf) {
     char c;
 
-    print("0x");
+    if (pf)
+        print("0x");
 
     c = nibtoa (b >> 4); // upper nibble
 

--- a/drivers/screen.h
+++ b/drivers/screen.h
@@ -31,5 +31,5 @@ void print_at(const char *s, int row, int col);
 void print(const char *s);
 void clear_screen(void);
 void print_byteb (unsigned char b);
-void print_byteh (unsigned char b);
+void print_byteh (unsigned char b, int pf);
 #endif

--- a/kernel/idt.c
+++ b/kernel/idt.c
@@ -1,0 +1,7 @@
+/*
+
+    Defining the IDT in C.
+
+*/
+
+

--- a/kernel/idt.h
+++ b/kernel/idt.h
@@ -1,0 +1,24 @@
+#ifndef __IDT_H__
+#define __IDT_H__
+
+#define IDT_TASK_TYPE (0x00000500)
+#define IDT_INTR_TYPE (0x00000600)
+#define IDT_TRAP_TYPE (0x00000700)
+
+#define IDT_DESCRIPTOR_H(offset, p, dpl, d, type)                     ( (offset & 0xFFFF0000U) | (type) | ( (p & 0x00000001U) << 15 ) | ( (dpl & 0x00000003U) << 13 ) | ( (d & 0x00000001U) << 11 ) )
+#define IDT_DESCRIPTOR_L(segment_sel, offset)                         ( ((segment_sel & 0x0000FFFFU) << 16) | (offset & 0x0000FFFFU) )
+
+#define IDT_X_GATE_DESCRIPTOR(p, dpl, d, type, segment_sel, offset)   ( ( ( 0x00000000FFFFFFFFULL & IDT_DESCRIPTOR_H(offset, p, dpl, d, type) ) << 32) | ( 0x00000000FFFFFFFFULL & IDT_DESCRIPTOR_L(segment_sel, offset) ) )
+
+#define IDT_TASK_GATE_DESCRIPTOR(p, dpl, segment_sel)                 IDT_X_GATE_DESCRIPTOR(p, dpl, 0U, IDT_TASK_TYPE, segment_sel, 0x00000000U)
+
+#define IDT_INTR_GATE_DESCRIPTOR(p, dpl, d, segment_sel, offset)      IDT_X_GATE_DESCRIPTOR(p, dpl, d, IDT_INTR_TYPE, segment_sel, offset)
+
+#define IDT_TRAP_GATE_DESCRIPTOR(p, dpl, d, segment_sel, offset)      IDT_X_GATE_DESCRIPTOR(p, dpl, d, IDT_TRAP_TYPE, segment_sel, offset)
+
+
+
+#define IDT_ENTRY_COUNT 34
+
+
+#endif

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -62,7 +62,7 @@ int main(void) {
     //unsigned long long t = 0;
     //print_byteh((unsigned char) sizeof(t));
     unsigned char *t = (unsigned char *) &idt[0];
-    t += 0x200 - 0x1000;
+    //t += 0x200 - 0x1000;
     unsigned int taddr = (unsigned int) t;
 
     for (int i = 7; i >= 0; i--) {

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -45,7 +45,7 @@ external variables do not appear to be working correctly e.g. unsigned int idt[1
 //#endif
 
 unsigned long long idt[] = {
-    0xFACECACADEADBEEF
+    0xFACECACADEADBEEF // ef be ` ad de ` ca ca ` ce fa // efbe adde caca cefa
 };
 
 int main(void) {
@@ -62,7 +62,9 @@ int main(void) {
     //unsigned long long t = 0;
     //print_byteh((unsigned char) sizeof(t));
     unsigned char *t = (unsigned char *) &idt[0];
+    t += 0x200 - 0x1000;
     unsigned int taddr = (unsigned int) t;
+
     for (int i = 7; i >= 0; i--) {
         print_byteh(t[i], 0);
     }

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -1,3 +1,14 @@
+/*
+
+Remarks:
+On moving the IDT into C.
+
+gcc is not reporting out of bounds access on arrays but cc does. e.g. int a[3]; int t = a[4]; does not generate an error.
+
+external variables do not appear to be working correctly e.g. unsigned int idt[1] = {0xDEADBEEF}; // printing idt[0] prints all 0's. Works fine as local variable.
+
+*/
+
 // []IMPORTANT: Add param checks in all C functions. []Avoid/remove unnecessary/dangerous macros. - Elements of Programming Style - Brian Kernighan [] fully specify function pre and post conditions.
 
 
@@ -8,6 +19,8 @@
 #include "../drivers/keyboard.h"
 #include "../mylibc/mylibc.h"
 #include "idt_v_print.h"
+#include "idt.h"
+
 
 /* [Index of Directives](https://gcc.gnu.org/onlinedocs/cpp/Index-of-Directives.html#Index-of-Directives)
     [] How to ensure my integers are of the size I expect?
@@ -31,6 +44,10 @@
     // #warning "pipi" // Just a warning, not fatal.
 //#endif
 
+unsigned long long idt[] = {
+    0xFACECACADEADBEEF
+};
+
 int main(void) {
     //int r;
     // unsigned char b;
@@ -39,12 +56,26 @@ int main(void) {
     // ps_2_ctrl_stat_t stat;
 
 
-    //clear_screen();
-    //print_at("Edsger Dijkstra!\n", 0, 0);
+    clear_screen();
+    print_at("Edsger Dijkstra!\n", 0, 0);
     //asm("int 21");
+    //unsigned long long t = 0;
+    //print_byteh((unsigned char) sizeof(t));
+    unsigned char *t = (unsigned char *) &idt[0];
+    unsigned int taddr = (unsigned int) t;
+    for (int i = 7; i >= 0; i--) {
+        print_byteh(t[i], 0);
+    }
+    print("\n");
+    print_byteh(taddr >> 24, 0);
+    print_byteh(taddr >> 16, 0);
+    print_byteh(taddr >> 8, 0);
+    print_byteh(taddr, 0);
 
 
 
+
+    //print_byteh(idt[0], 0);
 
     // while(1) { // Test getting both 1 byte and 2 byte scan codes using a single function.
     //     r = get_scan_code2(sc);

--- a/kernel/kernel.h
+++ b/kernel/kernel.h
@@ -1,0 +1,4 @@
+#ifndef __KERNEL_H__
+#define __KERNEL_H__
+
+#endif

--- a/kernel/kernel_entry.asm
+++ b/kernel/kernel_entry.asm
@@ -8,8 +8,8 @@
               ; The linker will substitute the final address.
 
 
-call init_pics
-call load_idtr ; also enables interrupts.
+; call init_pics
+; call load_idtr ; also enables interrupts.
 
 ; To link this program with the kernel use (order of .o files is essential):
 ; i386-elf-gcc -ffreestanding -c kernel.c -o kernel.o
@@ -19,6 +19,6 @@ call main ; Call the main function of our C kernel.
 
 jmp $ ; Infinite loop if/when the kernel returns.
 
-%include "boot/idt.asm"
+; %include "boot/idt.asm"
 
 

--- a/kernel/low_level.c
+++ b/kernel/low_level.c
@@ -32,9 +32,9 @@ unsigned char port_byte_in (unsigned short port) {
         Read from I/O port specified in DX into AL.
 
     */
-    __asm__("in al, dx" : "=a" (result) : "d" (port) );
+    // __asm__("in al, dx" : "=a" (result) : "d" (port) ); // Compile with: i386-elf-gcc -masm=intel
 
-    /* __asm__("in %%dx, %%al" : "=a" (result) : "d" (port) ); */ // Author's given assembly, I change the assembly syntax to NASM to be consistent with our other assembly code like that in the boot sector.
+    __asm__("in %%dx, %%al" : "=a" (result) : "d" (port) );  // Author's given assembly, I change the assembly syntax to NASM to be consistent with our other assembly code like that in the boot sector.
 
     return result;
 }
@@ -53,9 +53,9 @@ void port_byte_out (unsigned short port, unsigned char data) {
 
     */
 
-    __asm__("out dx, al" : :"a" (data), "d" (port) );
+    // __asm__("out dx, al" : :"a" (data), "d" (port) ); // Compile with: i386-elf-gcc -masm=intel
 
-    /*__asm__("out %% al, %%dx" : :"a" (data), "d" (port) ); See note above. */
+    __asm__("out %% al, %%dx" : :"a" (data), "d" (port) ); // See note above.
 }
 
 // TODO: port_WORD_in()


### PR DESCRIPTION
A bit of cleanup and additional comments added. Fixed error in which it would appear that C external variables were not working, they contained all 0's instead of the values they were initialized with. This was caused by not reading enough sectors from the floppy drive because the kernel had out sized the original number of sectors read. If future issues with external C variables arise ensure the size of kernel.bin is less than the number of sectors read from the floppy drive.

C extern error:

![extern_error](https://user-images.githubusercontent.com/1085688/97797570-2f9d4580-1bec-11eb-95bb-b10c9e4fd3f0.png)

